### PR TITLE
Fix wine cellar interactions

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -15,7 +15,6 @@ import HelpView from '@/views/help/HelpView';
 import WineFormModal from '@/components/WineFormModal';
 import ExperienceWineModal from '@/components/ExperienceWineModal';
 import FoodPairingModal from '@/components/FoodPairingModal';
-import ReverseFoodPairingModal from '@/components/ReverseFoodPairingModal';
 import AuthModal from '@/components/AuthModal';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import AlertMessage from '@/components/AlertMessage';
@@ -57,7 +56,8 @@ export default function HomePage() {
     handleDeleteExperiencedWine,
     handleEraseAllWines,
     isLoadingAction,
-    actionError
+    actionError,
+    setActionError
   } = useWineActions(db, user?.uid, appId, msg => setCsvImportStatus({ message: msg, type: 'error', errors: [] }));
 
   // Global error
@@ -130,9 +130,9 @@ export default function HomePage() {
           <CellarView
             wines={wines}
             isLoadingAction={isLoadingAction}
-            addWine={w=>handleAddWine(w,wines)}
-            updateWine={(id,d)=>handleUpdateWine(id,d,wines)}
-            deleteWine={handleDeleteWine}
+            handleOpenWineForm={wine => setWineToEdit(wine)}
+            confirmExperienceWine={id => setWineToExperience(id)}
+            handleOpenFoodPairing={wine => setPairingWine(wine)}
           />
         )}
         {view==='drinksoon' && (
@@ -145,9 +145,7 @@ export default function HomePage() {
             handleOpenFoodPairing={wine => setPairingWine(wine)}
             isLoadingAction={isLoadingAction}
             error={actionError}
-            setError={msg => {/* clear or set actionError state */}
-              /* e.g. setActionError(msg) */
-            }
+            setError={setActionError}
 
             // the modal state you already have:
             wineFormOpen={!!wineToEdit}

--- a/hooks/useWineActions.js
+++ b/hooks/useWineActions.js
@@ -187,5 +187,6 @@ export default function useWineActions(db, userId, appId, setError) {
     handleEraseAllWines,
     isLoadingAction,
     actionError,
+    setActionError,
   };
 }

--- a/views/DrinkSoonView/DrinkSoonView.js
+++ b/views/DrinkSoonView/DrinkSoonView.js
@@ -98,7 +98,7 @@ const DrinkSoonView = ({
         wine={selectedPairingWine}
       />
 
-      <AlertMessage error={error} onClose={() => setError(null)} />
+      <AlertMessage message={error} type="error" onDismiss={() => setError(null)} />
     </>
   );
 };

--- a/views/cellar/CellarView.js
+++ b/views/cellar/CellarView.js
@@ -11,9 +11,9 @@ const CellarView = ({
   wines = [],
   isLoading = false, // ✅ Accept isLoading prop
   isLoadingAction,
-  addWine,
-  updateWine,
-  deleteWine,
+  handleOpenWineForm,
+  confirmExperienceWine,
+  handleOpenFoodPairing,
 }) => {
   const allWines = wines;
 
@@ -21,7 +21,7 @@ const CellarView = ({
     <div className="p-6">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-semibold text-slate-800 dark:text-slate-100">My Wine Cellar</h1>
-        <AddWineButton onAdd={addWine} />
+        <AddWineButton onAdd={() => handleOpenWineForm(null)} />
       </div>
 
       {(isLoading || isLoadingAction) && (
@@ -36,8 +36,9 @@ const CellarView = ({
             <WineItem
               key={wine.id}
               wine={wine}
-              onUpdate={updateWine}
-              onDelete={deleteWine}
+              onEdit={() => handleOpenWineForm(wine)}
+              onExperience={() => confirmExperienceWine(wine.id)}
+              onPairFood={() => handleOpenFoodPairing(wine)}
             />
           ))}
         </div>

--- a/views/experienced/ExperiencedWinesView.js
+++ b/views/experienced/ExperiencedWinesView.js
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import ExperiencedWineItem from '@/components/ExperiencedWineItem';
 import { useFirebaseData, useWineActions } from '@/hooks';
 import AlertMessage from '@/components/AlertMessage';
@@ -12,33 +12,37 @@ const CheckCircleIcon = ({ className = "w-5 h-5" }) => (
   </svg>
 );
 
-const ExperiencedWinesView = () => {
+const ExperiencedWinesView = ({ experiencedWines: experiencedWinesProp, onDelete }) => {
   const {
     db,
     user,
     appId,
     experiencedWines,
-    error,
-    setError
+    dataError
   } = useFirebaseData();
+
+  const [error, setError] = useState(null);
 
   const { isLoadingAction, deleteExperiencedWine } = useWineActions(db, user?.uid, appId, setError);
 
+  const wines = experiencedWinesProp || experiencedWines;
+  const handleDelete = onDelete || ((id) => deleteExperiencedWine(id));
+
   useEffect(() => {
-    console.log("DEBUG: Experienced wines received:", experiencedWines.map(w => ({ id: w.id, name: w.name || w.producer })));
-  }, [experiencedWines]);
+    console.log("DEBUG: Experienced wines received:", wines.map(w => ({ id: w.id, name: w.name || w.producer })));
+  }, [wines]);
 
   return (
     <>
       <h2 className="text-2xl font-semibold text-slate-700 dark:text-slate-200 mb-4 mt-8">Experienced Wines</h2>
 
-      {experiencedWines.length > 0 ? (
+      {wines.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {experiencedWines.map(wine => (
+          {wines.map(wine => (
             <ExperiencedWineItem
               key={wine.id}
               wine={wine}
-              onDelete={() => deleteExperiencedWine(wine.id)}
+              onDelete={() => handleDelete(wine.id)}
               loading={isLoadingAction}
             />
           ))}
@@ -51,7 +55,11 @@ const ExperiencedWinesView = () => {
         </div>
       )}
 
-      <AlertMessage error={error} onClose={() => setError(null)} />
+      <AlertMessage
+        message={dataError || error}
+        type="error"
+        onDismiss={() => setError(null)}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Summary
- wire cellar view buttons to open edit/experience/pairing modals
- update main page to supply modal handlers to the cellar view
- fix AddWineButton to open an empty wine form
- surface action errors correctly and expose setter
- display alert messages using correct props
- make `ExperiencedWinesView` reuse provided data if available
- remove unused ReverseFoodPairingModal import

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_686a976efe5c833084b8ae0bfa775b62