### PR TITLE
Fix editing wines from Drink Soon view

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -139,26 +139,13 @@ export default function HomePage() {
           <DrinkSoonView
             // ◀ PASS the full list
             wines={wines}
-            // callbacks to open/close/modal control
+            // callbacks to open modal or trigger actions
             handleOpenWineForm={wine => setWineToEdit(wine)}
             confirmExperienceWine={id => setWineToExperience(id)}
             handleOpenFoodPairing={wine => setPairingWine(wine)}
             isLoadingAction={isLoadingAction}
             error={actionError}
             setError={setActionError}
-
-            // the modal state you already have:
-            wineFormOpen={!!wineToEdit}
-            onWineFormClose={() => setWineToEdit(null)}
-            experienceOpen={!!wineToExperience}
-            onExperienceClose={() => setWineToExperience(null)}
-            foodPairingOpen={!!pairingWine}
-            onFoodPairingClose={() => setPairingWine(null)}
-
-            // selected items:
-            selectedWine={wineToEdit}
-            selectedExperienceWineId={wineToExperience}
-            selectedPairingWine={pairingWine}
 			/>
         )}
         {view==='experienced' && (

--- a/views/DrinkSoonView/DrinkSoonView.js
+++ b/views/DrinkSoonView/DrinkSoonView.js
@@ -2,9 +2,6 @@
 
 import React, { useEffect, useMemo } from 'react';
 import WineItem from '@/components/WineItem';
-import WineFormModal from '@/components/WineFormModal';
-import ExperienceWineModal from '@/components/ExperienceWineModal';
-import FoodPairingModal from '@/components/FoodPairingModal';
 import AlertMessage from '@/components/AlertMessage';
 
 // --- Icons ---
@@ -22,17 +19,6 @@ const DrinkSoonView = ({
   error,
   setError,
   isLoadingAction,
-  // Modal control from parent
-  wineFormOpen,
-  onWineFormClose,
-  experienceOpen,
-  onExperienceClose,
-  foodPairingOpen,
-  onFoodPairingClose,
-  // Selected items passed by parent
-  selectedWine,
-  selectedExperienceWineId,
-  selectedPairingWine,
 }) => {
   // Compute wines approaching end based on drinkingWindowEndYear
   const winesApproachingEnd = useMemo(() => {
@@ -78,25 +64,6 @@ const DrinkSoonView = ({
           <p className="text-slate-500 dark:text-slate-400">All wines are currently within their drinking window.</p>
         </div>
       )}
-
-      {/* Modals (controlled by parent) */}
-      <WineFormModal
-        isOpen={wineFormOpen}
-        onClose={onWineFormClose}
-        wine={selectedWine}
-        loading={isLoadingAction}
-      />
-      <ExperienceWineModal
-        isOpen={experienceOpen}
-        onClose={onExperienceClose}
-        wineId={selectedExperienceWineId}
-        loading={isLoadingAction}
-      />
-      <FoodPairingModal
-        isOpen={foodPairingOpen}
-        onClose={onFoodPairingClose}
-        wine={selectedPairingWine}
-      />
 
       <AlertMessage message={error} type="error" onDismiss={() => setError(null)} />
     </>


### PR DESCRIPTION
## Summary
- remove unused modals from DrinkSoonView
- simplify props in `app/page.jsx` now that DrinkSoonView no longer manages its own modals

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b66cd211883308c64a18c20c61440