### PR TITLE
Add editing for experienced wines

### DIFF
--- a/components/EditExperiencedWineModal.js
+++ b/components/EditExperiencedWineModal.js
@@ -1,0 +1,172 @@
+"use client";
+import React, { useState, useEffect } from 'react';
+import Modal from './Modal.js';
+import AlertMessage from './AlertMessage.js';
+import { Timestamp } from 'firebase/firestore';
+
+const StarIcon = ({ className = "w-4 h-4", onClick }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" onClick={onClick}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.109 5.625.441a.562.562 0 0 1 .322.978l-4.307 3.972 1.282 5.586a.562.562 0 0 1-.84.61l-4.908-2.921-4.908 2.921a.562.562 0 0 1-.84-.61l1.282-5.586-4.307-3.972a.562.562 0 0 1 .322-.978l5.625-.441L11.48 3.499Z" />
+  </svg>
+);
+
+const EditExperiencedWineModal = ({ isOpen, onClose, wine, onSubmit, onMoveBack }) => {
+  const [formData, setFormData] = useState({
+    name: '',
+    producer: '',
+    year: '',
+    region: '',
+    color: 'red',
+    location: '',
+    drinkingWindowStartYear: '',
+    drinkingWindowEndYear: '',
+    tastingNotes: '',
+    rating: 0,
+    consumedDate: new Date().toISOString().slice(0,10),
+    addedAt: null,
+  });
+  const [formError, setFormError] = useState('');
+
+  useEffect(() => {
+    if (wine) {
+      setFormData({
+        name: wine.name || '',
+        producer: wine.producer || '',
+        year: wine.year || '',
+        region: wine.region || '',
+        color: wine.color || 'red',
+        location: wine.location || '',
+        drinkingWindowStartYear: wine.drinkingWindowStartYear || '',
+        drinkingWindowEndYear: wine.drinkingWindowEndYear || '',
+        tastingNotes: wine.tastingNotes || '',
+        rating: wine.rating || 0,
+        consumedDate: wine.consumedAt ? (wine.consumedAt instanceof Timestamp ? wine.consumedAt.toDate() : new Date(wine.consumedAt)).toISOString().slice(0,10) : new Date().toISOString().slice(0,10),
+        addedAt: wine.addedAt || null,
+      });
+    }
+    setFormError('');
+  }, [wine, isOpen]);
+
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const validateBasic = () => {
+    if (!formData.producer || !formData.region || !formData.color || !formData.location) {
+      setFormError('Producer, Region, Color, and Location are required.');
+      return false;
+    }
+    if (formData.year && (isNaN(parseInt(formData.year)) || parseInt(formData.year) < 1000 || parseInt(formData.year) > new Date().getFullYear() + 10)) {
+      setFormError('Please enter a valid Year (e.g., 2020).');
+      return false;
+    }
+    const startYear = formData.drinkingWindowStartYear ? parseInt(formData.drinkingWindowStartYear,10) : null;
+    const endYear = formData.drinkingWindowEndYear ? parseInt(formData.drinkingWindowEndYear,10) : null;
+    if (formData.drinkingWindowStartYear && (isNaN(startYear) || startYear < 1000 || startYear > new Date().getFullYear() + 50)) {
+      setFormError('Please enter a valid Drinking Window Start Year.');
+      return false;
+    }
+    if (formData.drinkingWindowEndYear && (isNaN(endYear) || endYear < 1000 || endYear > new Date().getFullYear() + 100)) {
+      setFormError('Please enter a valid Drinking Window End Year.');
+      return false;
+    }
+    if (startYear && endYear && startYear > endYear) {
+      setFormError('Drinking Window Start Year cannot be after End Year.');
+      return false;
+    }
+    if (!formData.consumedDate) {
+      setFormError('Consumed date is required.');
+      return false;
+    }
+    return true;
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    setFormError('');
+    if (!validateBasic()) return;
+    onSubmit(formData);
+  };
+
+  const handleMoveBack = e => {
+    e.preventDefault();
+    setFormError('');
+    if (!validateBasic()) return;
+    onMoveBack(formData);
+  };
+
+  const wineColorOptions = ['red','white','rose','sparkling','other'];
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={wine ? `Edit Experienced Wine: ${wine.name || wine.producer}` : 'Edit Wine'}>
+      {formError && <AlertMessage message={formError} type="error" onDismiss={() => setFormError('')} />}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="name" className="block text-sm font-medium text-slate-700 dark:text-slate-300">Name (Optional)</label>
+          <input type="text" id="name" name="name" value={formData.name} onChange={handleChange} className="mt-1 block w-full p-2.5 rounded-md border border-slate-300 dark:border-slate-600 focus:ring-red-500 focus:border-red-500 shadow-sm sm:text-sm dark:bg-slate-700 dark:text-slate-200" />
+        </div>
+        <div>
+          <label htmlFor="producer" className="block text-sm font-medium text-slate-700 dark:text-slate-300">Producer <span className="text-red-500">*</span></label>
+          <input type="text" id="producer" name="producer" value={formData.producer} onChange={handleChange} required className="mt-1 block w-full p-2.5 rounded-md border border-slate-300 dark:border-slate-600 focus:ring-red-500 focus:border-red-500 shadow-sm sm:text-sm dark:bg-slate-700 dark:text-slate-200" />
+        </div>
+        <div>
+          <label htmlFor="year" className="block text-sm font-medium text-slate-700 dark:text-slate-300">Year</label>
+          <input type="number" id="year" name="year" value={formData.year} onChange={handleChange} className="mt-1 block w-full p-2.5 rounded-md border border-slate-300 dark:border-slate-600 focus:ring-red-500 focus:border-red-500 shadow-sm sm:text-sm dark:bg-slate-700 dark:text-slate-200" />
+        </div>
+        <div>
+          <label htmlFor="region" className="block text-sm font-medium text-slate-700 dark:text-slate-300">Region <span className="text-red-500">*</span></label>
+          <input type="text" id="region" name="region" value={formData.region} onChange={handleChange} required className="mt-1 block w-full p-2.5 rounded-md border border-slate-300 dark:border-slate-600 focus:ring-red-500 focus:border-red-500 shadow-sm sm:text-sm dark:bg-slate-700 dark:text-slate-200" />
+        </div>
+        <div>
+          <label htmlFor="color" className="block text-sm font-medium text-slate-700 dark:text-slate-300">Color <span className="text-red-500">*</span></label>
+          <select id="color" name="color" value={formData.color} onChange={handleChange} required className="mt-1 block w-full p-2.5 rounded-md border border-slate-300 dark:border-slate-600 focus:ring-red-500 focus:border-red-500 shadow-sm sm:text-sm dark:bg-slate-700 dark:text-slate-200">
+            {wineColorOptions.map(opt => (<option key={opt} value={opt} className="capitalize">{opt.charAt(0).toUpperCase()+opt.slice(1)}</option>))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="location" className="block text-sm font-medium text-slate-700 dark:text-slate-300">Cellar Location <span className="text-red-500">*</span></label>
+          <input type="text" id="location" name="location" value={formData.location} onChange={handleChange} required className="mt-1 block w-full p-2.5 rounded-md border border-slate-300 dark:border-slate-600 focus:ring-red-500 focus:border-red-500 shadow-sm sm:text-sm dark:bg-slate-700 dark:text-slate-200" />
+        </div>
+        <div className="border-t border-slate-200 dark:border-slate-700 pt-4 mt-4">
+          <h3 className="base font-semibold text-slate-700 dark:text-slate-200 mb-2">Drinking Window (Optional)</h3>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="drinkingWindowStartYear" className="block text-sm font-medium text-slate-700 dark:text-slate-300">Start Year</label>
+              <input type="number" id="drinkingWindowStartYear" name="drinkingWindowStartYear" value={formData.drinkingWindowStartYear} onChange={handleChange} className="mt-1 block w-full p-2.5 rounded-md border border-slate-300 dark:border-slate-600 focus:ring-red-500 focus:border-red-500 shadow-sm sm:text-sm dark:bg-slate-700 dark:text-slate-200" />
+            </div>
+            <div>
+              <label htmlFor="drinkingWindowEndYear" className="block text-sm font-medium text-slate-700 dark:text-slate-300">End Year</label>
+              <input type="number" id="drinkingWindowEndYear" name="drinkingWindowEndYear" value={formData.drinkingWindowEndYear} onChange={handleChange} className="mt-1 block w-full p-2.5 rounded-md border border-slate-300 dark:border-slate-600 focus:ring-red-500 focus:border-red-500 shadow-sm sm:text-sm dark:bg-slate-700 dark:text-slate-200" />
+            </div>
+          </div>
+        </div>
+        <div>
+          <label htmlFor="consumedDate" className="block text-sm font-medium text-slate-700 dark:text-slate-300">Date Consumed <span className="text-red-500">*</span></label>
+          <input type="date" id="consumedDate" name="consumedDate" value={formData.consumedDate} onChange={handleChange} required className="mt-1 block w-full p-2.5 rounded-md border border-slate-300 dark:border-slate-600 focus:ring-red-500 focus:border-red-500 shadow-sm sm:text-sm dark:bg-slate-700 dark:text-slate-200" />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Rating</label>
+          <div className="flex items-center mt-1 space-x-1">
+            {[1,2,3,4,5].map(star => (
+              <StarIcon key={star} className={`w-6 h-6 inline-block cursor-pointer ${star <= formData.rating ? 'text-yellow-400' : 'text-slate-300 dark:text-slate-600'}`} onClick={() => setFormData(prev => ({...prev, rating: star}))} />
+            ))}
+          </div>
+        </div>
+        <div>
+          <label htmlFor="tastingNotes" className="block text-sm font-medium text-slate-700 dark:text-slate-300">Tasting Notes</label>
+          <textarea id="tastingNotes" name="tastingNotes" value={formData.tastingNotes} onChange={handleChange} rows="4" className="mt-1 block w-full p-2.5 rounded-md border border-slate-300 dark:border-slate-600 focus:ring-red-500 focus:border-red-500 shadow-sm sm:text-sm dark:bg-slate-700 dark:text-slate-200" placeholder="e.g., Fruity, earthy, paired well with..."></textarea>
+        </div>
+        <div className="flex justify-between space-x-2 pt-2">
+          <button type="button" onClick={onClose} className="px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-600 hover:bg-slate-200 dark:hover:bg-slate-500 rounded-md border border-slate-300 dark:border-slate-500">Cancel</button>
+          <div className="space-x-2">
+            <button type="button" onClick={handleMoveBack} className="px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-md shadow-sm">Move Back to Cellar</button>
+            <button type="submit" className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md shadow-sm">Save Changes</button>
+          </div>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default EditExperiencedWineModal;

--- a/components/ExperiencedWineItem.js
+++ b/components/ExperiencedWineItem.js
@@ -12,8 +12,13 @@ const TrashIcon = ({ className = "w-5 h-5" }) => (
         <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12.56 0c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
     </svg>
 );
+const EditIcon = ({ className = "w-5 h-5" }) => (
+    <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+    </svg>
+);
 
-const ExperiencedWineItem = ({ wine, onDelete }) => { 
+const ExperiencedWineItem = ({ wine, onDelete, onEdit }) => {
     const wineColors = {
         red: 'bg-red-200 dark:bg-red-800 border-red-400 dark:border-red-600',
         white: 'bg-yellow-100 dark:bg-yellow-700 border-yellow-300 dark:border-yellow-500',
@@ -51,7 +56,14 @@ const ExperiencedWineItem = ({ wine, onDelete }) => {
             </div>
             <div className="p-4 bg-slate-50 dark:bg-slate-700/50 flex justify-end space-x-2 border-t border-slate-200 dark:border-slate-700">
                 <button
-                    onClick={onDelete} 
+                    onClick={onEdit}
+                    title="Edit Experienced Wine"
+                    className="p-2 rounded-md text-sm text-blue-600 hover:bg-blue-100 dark:text-blue-400 dark:hover:bg-blue-700 transition-colors"
+                >
+                    <EditIcon />
+                </button>
+                <button
+                    onClick={onDelete}
                     title="Delete Experienced Wine"
                     className="p-2 rounded-md text-sm text-red-600 hover:bg-red-100 dark:text-red-400 dark:hover:bg-red-700 transition-colors"
                 >

--- a/components/index.js
+++ b/components/index.js
@@ -4,6 +4,7 @@ export { default as WineItem } from './WineItem';
 export { default as WineFormModal } from './WineFormModal';
 export { default as ExperienceWineModal } from './ExperienceWineModal';
 export { default as ExperiencedWineItem } from './ExperiencedWineItem';
+export { default as EditExperiencedWineModal } from './EditExperiencedWineModal';
 export { default as ReverseFoodPairingModal } from './ReverseFoodPairingModal';
 export { default as FoodPairingModal } from './FoodPairingModal';
 export { default as Modal } from './Modal';


### PR DESCRIPTION
## Summary
- enable edit button for experienced wines
- introduce modal for editing experienced wines and moving them back to cellar
- wire up new actions in wine utilities and experienced view

## Testing
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cb9f131b88330996aa41d317bae86