### PR TITLE
Sort DrinkSoon wines by end window

### DIFF
--- a/views/DrinkSoonView/DrinkSoonView.js
+++ b/views/DrinkSoonView/DrinkSoonView.js
@@ -23,10 +23,12 @@ const DrinkSoonView = ({
   // Compute wines approaching end based on drinkingWindowEndYear
   const winesApproachingEnd = useMemo(() => {
     const currentYear = new Date().getFullYear();
-    return wines.filter(wine => {
-      const end = wine.drinkingWindowEndYear;
-      return typeof end === 'number' && end <= currentYear;
-    });
+    return wines
+      .filter(wine => {
+        const end = wine.drinkingWindowEndYear;
+        return typeof end === 'number' && end <= currentYear;
+      })
+      .sort((a, b) => (a.drinkingWindowEndYear || 0) - (b.drinkingWindowEndYear || 0));
   }, [wines]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- display wines approaching the end of their drinking window in chronological order

## Testing
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cbd9f058483308dbc64b3bfc5d341