### PR TITLE
Add CSV export buttons

### DIFF
--- a/views/experienced/ExperiencedWinesView.js
+++ b/views/experienced/ExperiencedWinesView.js
@@ -53,7 +53,7 @@ const ExperiencedWinesView = ({ experiencedWines: experiencedWinesProp, onDelete
         </div>
       ) : (
         <div className="text-center p-10 bg-white dark:bg-slate-800 rounded-lg shadow-md mt-6">
-          <CheckCircleIcon className="w-16 h-16 mx-auto text-slate-400 dark:text-slate-500 mb-4" />
+          <CheckCircleIcon className="w-12 h-12 mx-auto text-slate-400 dark:text-slate-500 mb-4" />
           <h3 className="text-xl font-semibold mb-2 text-slate-700 dark:text-slate-200">No experienced wines yet.</h3>
           <p className="text-slate-500 dark:text-slate-400">When you drink a wine, it will appear here!</p>
         </div>

--- a/views/importExport/ImportExportView.js
+++ b/views/importExport/ImportExportView.js
@@ -53,6 +53,20 @@ export default function ImportExportView({
           >
             {isImportingCsv ? 'Importing...' : 'Import CSV'}
           </button>
+          <button
+            onClick={handleExportCsv}
+            disabled={wines.length === 0}
+            className="bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2 px-4 rounded disabled:opacity-60"
+          >
+            Export Cellar
+          </button>
+          <button
+            onClick={handleExportExperiencedCsv}
+            disabled={experiencedWines.length === 0}
+            className="bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2 px-4 rounded disabled:opacity-60"
+          >
+            Export Experienced
+          </button>
         </div>
         {message && (
           <div className="mt-4">
@@ -71,36 +85,6 @@ export default function ImportExportView({
             />
           </div>
         )}
-      </section>
-
-      {/* Export Active */}
-      <section className="mb-8 p-6 bg-white dark:bg-slate-800 rounded-lg shadow">
-        <h2 className="text-xl font-semibold text-slate-700 dark:text-slate-200 mb-3">
-          Export Wines to CSV
-        </h2>
-        <button
-          onClick={handleExportCsv}
-          disabled={wines.length === 0}
-          className="bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2 px-4 rounded disabled:opacity-60 flex items-center space-x-2"
-        >
-          <UploadIcon className="rotate-180" />
-          <span>Export Cellar</span>
-        </button>
-      </section>
-
-      {/* Export Experienced */}
-      <section className="mb-8 p-6 bg-white dark:bg-slate-800 rounded-lg shadow">
-        <h2 className="text-xl font-semibold text-slate-700 dark:text-slate-200 mb-3">
-          Export Experienced Wines
-        </h2>
-        <button
-          onClick={handleExportExperiencedCsv}
-          disabled={experiencedWines.length === 0}
-          className="bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2 px-4 rounded disabled:opacity-60 flex items-center space-x-2"
-        >
-          <UploadIcon className="rotate-180" />
-          <span>Export Experienced</span>
-        </button>
       </section>
 
       {/* Danger Zone */}

--- a/views/importExport/page.jsx
+++ b/views/importExport/page.jsx
@@ -3,13 +3,14 @@
 
 import { useState } from 'react';
 import ImportExportView from '@/views/importExport/ImportExportView';
+import { useFirebaseData } from '@/hooks';
+import { exportToCsv } from '@/utils';
 
 export default function ImportExportPage() {
   const [csvFile, setCsvFile] = useState(null);
   const [isImportingCsv, setIsImportingCsv] = useState(false);
   const [csvImportStatus, setCsvImportStatus] = useState({ message: '', type: '', errors: [] });
-  const [wines, setWines] = useState([]);
-  const [experiencedWines, setExperiencedWines] = useState([]);
+  const { wines, experiencedWines } = useFirebaseData();
 
   const handleCsvFileChange = (e) => setCsvFile(e.target.files[0]);
 
@@ -21,11 +22,10 @@ export default function ImportExportPage() {
     }, 1500);
   };
 
-  const handleExportCsv = () => alert('Exporting current cellar...');
-  const handleExportExperiencedCsv = () => alert('Exporting experienced wines...');
+  const handleExportCsv = () => exportToCsv(wines, 'my_cellar');
+  const handleExportExperiencedCsv = () => exportToCsv(experiencedWines, 'experienced_wines', undefined, true);
   const confirmEraseAllWines = () => {
     if (confirm('Are you sure you want to erase all wines? This cannot be undone.')) {
-      setWines([]);
       alert('All wines erased.');
     }
   };


### PR DESCRIPTION
## Summary
- expose export actions directly on the Import/Export page
- keep empty experienced icon consistent with Help view

## Testing
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cead095248330a67baab214bc412c