### PR TITLE
Add CSV export buttons

### DIFF
--- a/views/experienced/ExperiencedWinesView.js
+++ b/views/experienced/ExperiencedWinesView.js
@@ -53,7 +53,7 @@ const ExperiencedWinesView = ({ experiencedWines: experiencedWinesProp, onDelete
         </div>
       ) : (
         <div className="text-center p-10 bg-white dark:bg-slate-800 rounded-lg shadow-md mt-6">
-          <CheckCircleIcon className="w-16 h-16 mx-auto text-slate-400 dark:text-slate-500 mb-4" />
+          <CheckCircleIcon className="w-6 h-6 mx-auto text-slate-400 dark:text-slate-500 mb-4" />
           <h3 className="text-xl font-semibold mb-2 text-slate-700 dark:text-slate-200">No experienced wines yet.</h3>
           <p className="text-slate-500 dark:text-slate-400">When you drink a wine, it will appear here!</p>
         </div>

--- a/views/help/HelpView.js
+++ b/views/help/HelpView.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-const QuestionMarkCircleIcon = ({ className = "w-12 h-12" }) => (
+const QuestionMarkCircleIcon = ({ className = "w-6 h-6" }) => (
   <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
     <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
   </svg>
@@ -12,7 +12,7 @@ const HelpView = () => {
   return (
     <div className="p-6 bg-white dark:bg-slate-800 rounded-lg shadow-md">
       <h2 className="text-2xl font-semibold text-slate-700 dark:text-slate-200 mb-4 flex items-center space-x-2">
-        <QuestionMarkCircleIcon className="w-12 h-12 text-blue-600 dark:text-blue-400" />
+        <QuestionMarkCircleIcon className="w-6 h-6 text-blue-600 dark:text-blue-400" />
         <span>Welcome to My Wine Cellar App!</span>
       </h2>
       <p className="text-slate-600 dark:text-slate-300 mb-6">

--- a/views/importExport/ImportExportView.js
+++ b/views/importExport/ImportExportView.js
@@ -73,34 +73,29 @@ export default function ImportExportView({
         )}
       </section>
 
-      {/* Export Active */}
+      {/* Export */}
       <section className="mb-8 p-6 bg-white dark:bg-slate-800 rounded-lg shadow">
         <h2 className="text-xl font-semibold text-slate-700 dark:text-slate-200 mb-3">
           Export Wines to CSV
         </h2>
-        <button
-          onClick={handleExportCsv}
-          disabled={wines.length === 0}
-          className="bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2 px-4 rounded disabled:opacity-60 flex items-center space-x-2"
-        >
-          <UploadIcon className="rotate-180" />
-          <span>Export Cellar</span>
-        </button>
-      </section>
-
-      {/* Export Experienced */}
-      <section className="mb-8 p-6 bg-white dark:bg-slate-800 rounded-lg shadow">
-        <h2 className="text-xl font-semibold text-slate-700 dark:text-slate-200 mb-3">
-          Export Experienced Wines
-        </h2>
-        <button
-          onClick={handleExportExperiencedCsv}
-          disabled={experiencedWines.length === 0}
-          className="bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2 px-4 rounded disabled:opacity-60 flex items-center space-x-2"
-        >
-          <UploadIcon className="rotate-180" />
-          <span>Export Experienced</span>
-        </button>
+        <div className="flex flex-col sm:flex-row items-end gap-3">
+          <button
+            onClick={handleExportCsv}
+            disabled={wines.length === 0}
+            className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded disabled:opacity-60 flex items-center space-x-2"
+          >
+            <UploadIcon className="w-5 h-5 rotate-180" />
+            <span>Export Cellar</span>
+          </button>
+          <button
+            onClick={handleExportExperiencedCsv}
+            disabled={experiencedWines.length === 0}
+            className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded disabled:opacity-60 flex items-center space-x-2"
+          >
+            <UploadIcon className="w-5 h-5 rotate-180" />
+            <span>Export Experienced Wines</span>
+          </button>
+        </div>
       </section>
 
       {/* Danger Zone */}

--- a/views/importExport/page.jsx
+++ b/views/importExport/page.jsx
@@ -3,13 +3,14 @@
 
 import { useState } from 'react';
 import ImportExportView from '@/views/importExport/ImportExportView';
+import { useFirebaseData } from '@/hooks';
+import { exportToCsv } from '@/utils';
 
 export default function ImportExportPage() {
   const [csvFile, setCsvFile] = useState(null);
   const [isImportingCsv, setIsImportingCsv] = useState(false);
   const [csvImportStatus, setCsvImportStatus] = useState({ message: '', type: '', errors: [] });
-  const [wines, setWines] = useState([]);
-  const [experiencedWines, setExperiencedWines] = useState([]);
+  const { wines, experiencedWines } = useFirebaseData();
 
   const handleCsvFileChange = (e) => setCsvFile(e.target.files[0]);
 
@@ -21,11 +22,10 @@ export default function ImportExportPage() {
     }, 1500);
   };
 
-  const handleExportCsv = () => alert('Exporting current cellar...');
-  const handleExportExperiencedCsv = () => alert('Exporting experienced wines...');
+  const handleExportCsv = () => exportToCsv(wines, 'my_cellar');
+  const handleExportExperiencedCsv = () => exportToCsv(experiencedWines, 'experienced_wines', undefined, true);
   const confirmEraseAllWines = () => {
     if (confirm('Are you sure you want to erase all wines? This cannot be undone.')) {
-      setWines([]);
       alert('All wines erased.');
     }
   };


### PR DESCRIPTION
## Summary
- expose export actions directly on the Import/Export page
- keep empty experienced icon consistent with Help view
- shrink icon sizes to match Help page styling

## Testing
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cead095248330a67baab214bc412c