### PR TITLE
Fix tesseract worker initialization

### DIFF
--- a/components/WineFormModal.js
+++ b/components/WineFormModal.js
@@ -62,10 +62,7 @@ const WineFormModal = ({ isOpen, onClose, onSubmit, wine, allWines }) => {
         setIsProcessingImage(true);
         try {
             const { createWorker } = await import('tesseract.js');
-            const worker = createWorker();
-            await worker.load();
-            await worker.loadLanguage('eng');
-            await worker.initialize('eng');
+            const worker = await createWorker('eng');
             const { data: { text } } = await worker.recognize(file);
             await worker.terminate();
             const parsed = parseLabelText(text);


### PR DESCRIPTION
## Summary
- call createWorker with language and await result

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_686e286902108330855c8b15284a703c