### PR TITLE
Add apple web app meta

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,6 +24,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <meta name="apple-mobile-web-app-title" content="MyWineApp" />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
## Summary
- insert `<meta name="apple-mobile-web-app-title" content="MyWineApp" />`

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_686e402f2d008330a1f6827d2d42e59d