### PR TITLE
Refine loading spinner and search visibility

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -173,8 +173,8 @@ export default function HomePage() {
     }
   };
 
-  // Loading state
-  if (isLoadingAuth || !isAuthReady || isLoadingData) {
+  // Loading auth state
+  if (isLoadingAuth || !isAuthReady) {
     return (
       <div className="flex items-center justify-center h-screen"><LoadingSpinner /></div>
     );
@@ -230,15 +230,24 @@ export default function HomePage() {
           </button>
         ))}
       </nav>
-      <div className="p-4 bg-white dark:bg-slate-800">
-        <input type="text" placeholder="Search wines..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} className="w-full max-w-md p-2 border border-slate-300 dark:border-slate-600 rounded focus:outline-none" />
-      </div>
+      {(view==='cellar' || view==='drinksoon') && (
+        <div className="p-4 bg-white dark:bg-slate-800">
+          <input
+            type="text"
+            placeholder="Search wines..."
+            value={searchTerm}
+            onChange={e => setSearchTerm(e.target.value)}
+            className="w-full max-w-md p-2 border border-slate-300 dark:border-slate-600 rounded focus:outline-none"
+          />
+        </div>
+      )}
 
       {/* Main Content */}
       <main className="p-6 space-y-10">
         {view==='cellar' && (
           <CellarView
             wines={filteredWines}
+            isLoading={isLoadingData}
             isLoadingAction={isLoadingAction}
             handleOpenWineForm={wine => setWineToEdit(wine)}
             confirmExperienceWine={wine => setWineToExperience(wine)}


### PR DESCRIPTION
## Summary
- show the global loading spinner only while authentication is initializing
- pass loading state to `CellarView` so the spinner appears only when the cellar loads
- show the search box only in the *Cellar* and *Drink Soon* views

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_686e71c069408330b8e26768ab0aed5e