### PR TITLE
Remove extra export buttons from import view

### DIFF
--- a/views/importExport/ImportExportView.js
+++ b/views/importExport/ImportExportView.js
@@ -53,20 +53,6 @@ export default function ImportExportView({
           >
             {isImportingCsv ? 'Importing...' : 'Import CSV'}
           </button>
-          <button
-            onClick={handleExportCsv}
-            disabled={wines.length === 0}
-            className="bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2 px-4 rounded disabled:opacity-60"
-          >
-            Export Cellar
-          </button>
-          <button
-            onClick={handleExportExperiencedCsv}
-            disabled={experiencedWines.length === 0}
-            className="bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2 px-4 rounded disabled:opacity-60"
-          >
-            Export Experienced
-          </button>
         </div>
         {message && (
           <div className="mt-4">


### PR DESCRIPTION
## Summary
- tidy ImportExport view by removing Export buttons from the Import section

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_686e804ef8248330bea4fcf903195e3d