### PR TITLE
Fix drink soon action

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -319,9 +319,11 @@ export default function HomePage() {
       {wineToExperience && (
         <ExperienceWineModal
           isOpen
-          onClose={()=>setWineToExperience(null)}
+          onClose={() => setWineToExperience(null)}
           wine={wineToExperience}
-          onExperience={(notes,rating,date) => handleExperienceWine(wineToExperience.id,notes,rating,date,wines)}
+          onExperience={(notes, rating, date) =>
+            handleExperienceWine(wineToExperience, notes, rating, date)
+          }
         />
       )}
       {pairingWine && (

--- a/hooks/useWineActions.js
+++ b/hooks/useWineActions.js
@@ -144,16 +144,16 @@ export default function useWineActions(db, userId, appId, setError) {
   // ... other handlers (experience, delete, erase) unchanged ...
 
 
-  const handleExperienceWine = async (wineToMoveId, notes, rating, consumedDate, allWines) => {
+  const handleExperienceWine = async (wine, notes, rating, consumedDate) => {
     if (!db || !userId) return errorOut('Database not ready or user not logged in.');
+    if (!wine || !wine.id) return errorOut('Wine not found.');
     setIsLoadingAction(true);
-    const wineToMove = allWines.find(w => w.id === wineToMoveId);
-    if (!wineToMove) return errorOut('Wine not found.');
+    const wineToMove = wine;
 
     try {
       const batch = writeBatch(db);
-      const wineDocRef = doc(db, winesCollectionPath, wineToMoveId);
-      const experiencedWineDocRef = doc(db, experiencedWinesCollectionPath, wineToMoveId);
+      const wineDocRef = doc(db, winesCollectionPath, wine.id);
+      const experiencedWineDocRef = doc(db, experiencedWinesCollectionPath, wine.id);
 
       batch.set(experiencedWineDocRef, {
         ...wineToMove,


### PR DESCRIPTION
## Summary
- fix experience action to take wine object instead of searching by id
- call the updated handler in the main page

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_686f74dd5e24833085892659cec3c709