### PR TITLE
Implement email verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,19 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Email Verification
+
+Account creation requires entering a code that is sent to the provided email
+address. The API route `POST /api/sendVerificationEmail` uses SMTP credentials
+from the environment to deliver the code.
+
+Set the following variables in your `.env.local`:
+
+```bash
+EMAIL_SERVER_HOST=your.smtp.host
+EMAIL_SERVER_PORT=587
+EMAIL_SERVER_USER=username
+EMAIL_SERVER_PASS=password
+EMAIL_FROM="My App <no-reply@yourdomain.com>"
+```

--- a/app/api/sendVerificationEmail/route.js
+++ b/app/api/sendVerificationEmail/route.js
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import nodemailer from 'nodemailer';
+
+export async function POST(request) {
+  const { email, code } = await request.json();
+
+  if (!email || !code) {
+    return NextResponse.json({ error: 'Missing parameters.' }, { status: 400 });
+  }
+
+  const host = process.env.EMAIL_SERVER_HOST;
+  const port = parseInt(process.env.EMAIL_SERVER_PORT || '587', 10);
+  const user = process.env.EMAIL_SERVER_USER;
+  const pass = process.env.EMAIL_SERVER_PASS;
+  const from = process.env.EMAIL_FROM || user;
+
+  if (!host || !user || !pass) {
+    return NextResponse.json(
+      { error: 'Email server not configured.' },
+      { status: 500 }
+    );
+  }
+
+  const transporter = nodemailer.createTransport({ host, port, auth: { user, pass } });
+
+  try {
+    await transporter.sendMail({
+      from,
+      to: email,
+      subject: 'Your verification code',
+      text: `Your verification code is ${code}`
+    });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Failed to send email: ${err.message}` },
+      { status: 500 }
+    );
+  }
+}
+

--- a/components/EmailVerificationModal.js
+++ b/components/EmailVerificationModal.js
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Modal from './Modal';
+import AlertMessage from './AlertMessage';
+
+const EmailVerificationModal = ({ isOpen, onClose, onVerify, error }) => {
+  const [code, setCode] = useState('');
+  const [localError, setLocalError] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) {
+      setCode('');
+      setLocalError('');
+    }
+  }, [isOpen]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setLocalError('');
+    if (!code) {
+      setLocalError('Verification code is required.');
+      return;
+    }
+    onVerify(code);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Verify Email">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {(localError || error) && (
+          <AlertMessage
+            message={localError || error}
+            type="error"
+            onDismiss={() => setLocalError('')}
+          />
+        )}
+        <div>
+          <label htmlFor="verificationCode" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+            Verification Code
+          </label>
+          <input
+            type="text"
+            id="verificationCode"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            className="mt-1 block w-full p-2.5 rounded-md border border-slate-300 dark:border-slate-600 focus:ring-red-500 focus:border-red-500 shadow-sm sm:text-sm dark:bg-slate-700 dark:text-slate-200"
+            required
+          />
+        </div>
+        <div className="flex justify-end space-x-3 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-600 hover:bg-slate-200 dark:hover:bg-slate-500 rounded-md border border-slate-300 dark:border-slate-500"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+          >
+            Verify
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default EmailVerificationModal;
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "firebase": "^11.10.0",
         "lucide-react": "^0.525.0",
         "next": "15.3.5",
+        "nodemailer": "^6.10.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwindcss": "^3.4.3",
@@ -3259,6 +3260,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "firebase": "^11.10.0",
     "lucide-react": "^0.525.0",
     "next": "15.3.5",
+    "nodemailer": "^6.10.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwindcss": "^3.4.3",


### PR DESCRIPTION
## Summary
- add SMTP-powered API route `sendVerificationEmail`
- require a code sent to email before calling Firebase `register`
- new `EmailVerificationModal` for code entry
- document setup of email env vars
- add nodemailer dependency

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals")*
- `npm run build` *(fails: failed to fetch fonts and nodemailer not found until install)*

------
https://chatgpt.com/codex/tasks/task_e_686f7f3b0ab88330ad434b49f6acf989