### PR TITLE
Add password reset flow

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -86,7 +86,7 @@ export default function HomePage() {
   const [searchTerm, setSearchTerm] = useState('');
 
   // Auth
-  const { authError, isLoadingAuth, login, register, logout } = useAuthManager(auth);
+  const { authError, isLoadingAuth, login, register, resetPassword, logout } = useAuthManager(auth);
 
   // Data
   const { user, isAuthReady, wines, experiencedWines, isLoadingData, dataError, db, appId } = useFirebaseData();
@@ -391,6 +391,7 @@ export default function HomePage() {
           setIsRegister={setIsRegister}
           onLogin={login}
           onRegister={registerWithVerification}
+          onPasswordReset={resetPassword}
           error={authError}
           loading={isLoadingAuth}
         />

--- a/components/AuthModal.js
+++ b/components/AuthModal.js
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import Modal from './Modal';
 import AlertMessage from './AlertMessage';
+import PasswordResetModal from './PasswordResetModal';
 
 const AuthModal = ({
   isOpen,
@@ -11,12 +12,14 @@ const AuthModal = ({
   setIsRegister,
   onLogin,
   onRegister,
+  onPasswordReset,
   error,
   loading
 }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [localError, setLocalError] = useState('');
+  const [showResetModal, setShowResetModal] = useState(false);
 
   // Reset fields when the modal closes
   useEffect(() => {
@@ -24,6 +27,7 @@ const AuthModal = ({
       setEmail('');
       setPassword('');
       setLocalError('');
+      setShowResetModal(false);
     }
   }, [isOpen]);
 
@@ -128,9 +132,20 @@ const AuthModal = ({
             <button onClick={() => setIsRegister(true)} className="text-red-600 hover:underline">
               Register
             </button>
+            <br />
+            <button onClick={() => setShowResetModal(true)} className="text-red-600 hover:underline mt-2">
+              Forgot password?
+            </button>
           </>
         )}
       </p>
+      {showResetModal && (
+        <PasswordResetModal
+          isOpen={showResetModal}
+          onClose={() => setShowResetModal(false)}
+          onReset={onPasswordReset}
+        />
+      )}
     </Modal>
   );
 };

--- a/components/PasswordResetModal.js
+++ b/components/PasswordResetModal.js
@@ -1,0 +1,80 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Modal from './Modal';
+import AlertMessage from './AlertMessage';
+
+const PasswordResetModal = ({ isOpen, onClose, onReset }) => {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [type, setType] = useState('info');
+
+  useEffect(() => {
+    if (!isOpen) {
+      setEmail('');
+      setMessage('');
+      setType('info');
+    }
+  }, [isOpen]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!email) {
+      setMessage('Email is required.');
+      setType('error');
+      return;
+    }
+    const res = await onReset(email);
+    if (res?.success) {
+      setMessage(`If an account exists for ${email}, a reset link has been sent.`);
+      setType('success');
+    } else {
+      setMessage(res.error || 'Failed to send reset email.');
+      setType('error');
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Reset Password">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {message && (
+          <AlertMessage
+            message={message}
+            type={type}
+            onDismiss={() => setMessage('')}
+          />
+        )}
+        <div>
+          <label htmlFor="resetEmail" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+            Email
+          </label>
+          <input
+            type="email"
+            id="resetEmail"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1 block w-full p-2.5 rounded-md border border-slate-300 dark:border-slate-600 focus:ring-red-500 focus:border-red-500 shadow-sm sm:text-sm dark:bg-slate-700 dark:text-slate-200"
+            required
+          />
+        </div>
+        <div className="flex justify-end space-x-3 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-600 hover:bg-slate-200 dark:hover:bg-slate-500 rounded-md border border-slate-300 dark:border-slate-500"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md shadow-sm"
+          >
+            Send
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default PasswordResetModal;

--- a/components/index.js
+++ b/components/index.js
@@ -13,4 +13,5 @@ export { default as AuthModal } from './AuthModal';
 export { default as LoadingSpinner } from './LoadingSpinner'; // ✅ Add this line
 export { default as EmptyState } from './EmptyState';
 export { default as AddWineButton } from './AddWineButton';
+export { default as PasswordResetModal } from './PasswordResetModal';
 

--- a/hooks/useAuthManager.js
+++ b/hooks/useAuthManager.js
@@ -3,7 +3,8 @@ import { useState } from 'react';
 import {
   signOut,
   createUserWithEmailAndPassword,
-  signInWithEmailAndPassword
+  signInWithEmailAndPassword,
+  sendPasswordResetEmail
 } from 'firebase/auth';
 
 export const useAuthManager = (authInstance) => {
@@ -48,6 +49,24 @@ export const useAuthManager = (authInstance) => {
     }
   };
 
+  const resetPassword = async (email) => {
+    setIsLoadingAuth(true);
+    setAuthError(null);
+    try {
+      await sendPasswordResetEmail(authInstance, email);
+      return { success: true };
+    } catch (error) {
+      let message = 'Failed to send password reset email.';
+      if (error.code === 'auth/user-not-found') {
+        message = 'No account found with this email.';
+      }
+      setAuthError(message);
+      return { success: false, error: message };
+    } finally {
+      setIsLoadingAuth(false);
+    }
+  };
+
   const logout = async () => {
     setIsLoadingAuth(true);
     setAuthError(null);
@@ -68,6 +87,7 @@ export const useAuthManager = (authInstance) => {
     isLoadingAuth,
     login,
     register,
+    resetPassword,
     logout
   };
 };


### PR DESCRIPTION
## Summary
- add `resetPassword` API in `useAuthManager`
- create `PasswordResetModal`
- show reset link in `AuthModal`
- wire password reset into home page
- export modal from component index

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_686f846b8d0483308553d91552c71e7d