### PR TITLE
Add debug logs for Gmail OAuth2 route

### DIFF
--- a/app/api/sendVerificationEmail/route.js
+++ b/app/api/sendVerificationEmail/route.js
@@ -4,6 +4,7 @@ import { google } from 'googleapis';
 
 export async function POST(request) {
   const { email, code } = await request.json();
+  console.debug('Verification email request received', { email, code });
 
   if (!email || !code) {
     return NextResponse.json({ error: 'Missing parameters.' }, { status: 400 });
@@ -14,6 +15,13 @@ export async function POST(request) {
   const refreshToken = process.env.GMAIL_REFRESH_TOKEN;
   const gmailUser = process.env.GMAIL_USER || 'mycellarapplication@gmail.com';
   const redirectUri = process.env.NEXT_PUBLIC_URL;
+
+  console.debug('Loaded OAuth2 environment', {
+    clientIdExists: Boolean(clientId),
+    clientSecretExists: Boolean(clientSecret),
+    refreshTokenExists: Boolean(refreshToken),
+    redirectUri,
+  });
 
   if (!clientId || !clientSecret || !refreshToken) {
     return NextResponse.json(
@@ -28,7 +36,9 @@ export async function POST(request) {
   try {
     const tokenRes = await oAuth2Client.getAccessToken();
     accessToken = tokenRes.token;
+    console.debug('Obtained access token');
   } catch (err) {
+    console.error('Error acquiring access token', err);
     return NextResponse.json(
       { error: `Failed to acquire access token: ${err.message}` },
       { status: 500 }
@@ -47,15 +57,20 @@ export async function POST(request) {
     }
   });
 
+  console.debug('Nodemailer transporter configured for Gmail');
+
   try {
+    console.debug('Sending verification email to', email);
     await transporter.sendMail({
       from: `MyCellar <${gmailUser}>`,
       to: email,
       subject: 'Your verification code',
       text: `Your verification code is ${code}`
     });
+    console.debug('Verification email sent successfully');
     return NextResponse.json({ success: true });
   } catch (err) {
+    console.error('Error sending verification email', err);
     return NextResponse.json(
       { error: `Failed to send email: ${err.message}` },
       { status: 500 }


### PR DESCRIPTION
## Summary
- add console debug and error logs in the `sendVerificationEmail` API route

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_6870c682b22883309b46e68dc539ad73