### PR TITLE
Improve registration feedback

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,114 +1,220 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect, useMemo } from 'react';
-import { auth } from '@/lib/firebaseClient';
-import { useAuthManager } from '@/hooks/useAuthManager';
-import { useFirebaseData } from '@/hooks/useFirebaseData';
-import useFoodPairingAI from '@/hooks/useFoodPairingAI';
-import useWineActions from '@/hooks/useWineActions';
-import CellarView from '@/views/cellar/CellarView';
-import DrinkSoonView from '@/views/DrinkSoonView/DrinkSoonView';
-import ExperiencedWinesView from '@/views/experienced/ExperiencedWinesView';
-import ImportExportView from '@/views/importExport/ImportExportView';
-import FoodPairingView from '@/views/pairing/FoodPairingView';
-import HelpView from '@/views/help/HelpView';
-import WineFormModal from '@/components/WineFormModal';
-import ExperienceWineModal from '@/components/ExperienceWineModal';
-import FoodPairingModal from '@/components/FoodPairingModal';
-import ReverseFoodPairingModal from '@/components/ReverseFoodPairingModal';
-import AuthModal from '@/components/AuthModal';
-import EmailVerificationModal from '@/components/EmailVerificationModal';
-import LoadingSpinner from '@/components/LoadingSpinner';
-import AlertMessage from '@/components/AlertMessage';
-import { parseCsv, exportToCsv } from '@/utils';
+import React, { useState, useEffect, useMemo } from "react";
+import { auth } from "@/lib/firebaseClient";
+import { useAuthManager } from "@/hooks/useAuthManager";
+import { useFirebaseData } from "@/hooks/useFirebaseData";
+import useFoodPairingAI from "@/hooks/useFoodPairingAI";
+import useWineActions from "@/hooks/useWineActions";
+import CellarView from "@/views/cellar/CellarView";
+import DrinkSoonView from "@/views/DrinkSoonView/DrinkSoonView";
+import ExperiencedWinesView from "@/views/experienced/ExperiencedWinesView";
+import ImportExportView from "@/views/importExport/ImportExportView";
+import FoodPairingView from "@/views/pairing/FoodPairingView";
+import HelpView from "@/views/help/HelpView";
+import WineFormModal from "@/components/WineFormModal";
+import ExperienceWineModal from "@/components/ExperienceWineModal";
+import FoodPairingModal from "@/components/FoodPairingModal";
+import ReverseFoodPairingModal from "@/components/ReverseFoodPairingModal";
+import AuthModal from "@/components/AuthModal";
+import EmailVerificationModal from "@/components/EmailVerificationModal";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import AlertMessage from "@/components/AlertMessage";
+import { parseCsv, exportToCsv } from "@/utils";
 
 // --- Local Icons ---
 
 const UserIcon = ({ className = "w-4 h-4" }) => (
-  <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+  <svg
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
+    />
   </svg>
 );
 
 const WineBottleIcon = ({ className = "w-4 h-4" }) => (
-  <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M7.252 2.262A2.25 2.25 0 0 0 5.254 4.24v11.517a2.25 2.25 0 0 0 2.25 2.25h9a2.25 2.25 0 0 0 2.25-2.25V4.24a2.25 2.25 0 0 0-1.998-1.978A2.253 2.253 0 0 0 15 2.25H9c-1.014 0-1.881.676-2.172 1.622a2.24 2.24 0 0 1 .424-1.61ZM9 4.5h6M9 7.5h6m-6 3h6m-3.75 3h.008v.008h-.008V15Z" />
+  <svg
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M7.252 2.262A2.25 2.25 0 0 0 5.254 4.24v11.517a2.25 2.25 0 0 0 2.25 2.25h9a2.25 2.25 0 0 0 2.25-2.25V4.24a2.25 2.25 0 0 0-1.998-1.978A2.253 2.253 0 0 0 15 2.25H9c-1.014 0-1.881.676-2.172 1.622a2.24 2.24 0 0 1 .424-1.61ZM9 4.5h6M9 7.5h6m-6 3h6m-3.75 3h.008v.008h-.008V15Z"
+    />
   </svg>
 );
 
 const ClockIcon = ({ className = "w-4 h-4" }) => (
-  <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+  <svg
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+    />
   </svg>
 );
 
 const StarIcon = ({ className = "w-4 h-4" }) => (
-  <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
+  <svg
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"
+    />
   </svg>
 );
 
 const SparklesIcon = ({ className = "w-4 h-4" }) => (
-  <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" />
+  <svg
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z"
+    />
   </svg>
 );
 
 const UploadIcon = ({ className = "w-4 h-4" }) => (
-  <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
+  <svg
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
+    />
   </svg>
 );
 
 const QuestionMarkCircleIcon = ({ className = "w-4 h-4" }) => (
-  <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
+  <svg
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"
+    />
   </svg>
 );
 
 export default function HomePage() {
   // UI state
-  const [view, setView] = useState('cellar');
+  const [view, setView] = useState("cellar");
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [isRegister, setIsRegister] = useState(false);
   const [showVerificationModal, setShowVerificationModal] = useState(false);
   const [pendingRegistration, setPendingRegistration] = useState(null);
-  const [verificationError, setVerificationError] = useState('');
+  const [verificationError, setVerificationError] = useState("");
+  const [verificationMessage, setVerificationMessage] = useState("");
   const [csvFile, setCsvFile] = useState(null);
-  const [csvImportStatus, setCsvImportStatus] = useState({ message: '', type: '', errors: [] });
-  const [foodForReversePairing, setFoodForReversePairing] = useState('');
+  const [csvImportStatus, setCsvImportStatus] = useState({
+    message: "",
+    type: "",
+    errors: [],
+  });
+  const [foodForReversePairing, setFoodForReversePairing] = useState("");
   const [wineToEdit, setWineToEdit] = useState(null);
   const [wineToExperience, setWineToExperience] = useState(null);
   const [pairingWine, setPairingWine] = useState(null);
-  const [pairingSuggestion, setPairingSuggestion] = useState('');
+  const [pairingSuggestion, setPairingSuggestion] = useState("");
   const [isLoadingPairing, setIsLoadingPairing] = useState(false);
   const [showReversePairingModal, setShowReversePairingModal] = useState(false);
-  const [searchTerm, setSearchTerm] = useState('');
+  const [searchTerm, setSearchTerm] = useState("");
 
   // Auth
-  const { authError, isLoadingAuth, login, register, resetPassword, logout } = useAuthManager(auth);
+  const { authError, isLoadingAuth, login, register, resetPassword, logout } =
+    useAuthManager(auth);
 
   // Data
-  const { user, isAuthReady, wines, experiencedWines, isLoadingData, dataError, db, appId } = useFirebaseData();
+  const {
+    user,
+    isAuthReady,
+    wines,
+    experiencedWines,
+    isLoadingData,
+    dataError,
+    db,
+    appId,
+  } = useFirebaseData();
 
   // Compute soon-to-drink
   const winesApproachingEnd = useMemo(() => {
     const current = new Date().getFullYear();
-    return wines.filter(w => w.drinkingWindowEndYear && w.drinkingWindowEndYear <= current);
+    return wines.filter(
+      (w) => w.drinkingWindowEndYear && w.drinkingWindowEndYear <= current,
+    );
   }, [wines]);
 
   const filteredWines = useMemo(() => {
     if (!searchTerm) return wines;
     const term = searchTerm.toLowerCase();
-    return wines.filter(w =>
-      [w.name, w.producer, w.region, w.color, w.location, w.year && String(w.year)]
+    return wines.filter((w) =>
+      [
+        w.name,
+        w.producer,
+        w.region,
+        w.color,
+        w.location,
+        w.year && String(w.year),
+      ]
         .filter(Boolean)
-        .some(val => String(val).toLowerCase().includes(term))
+        .some((val) => String(val).toLowerCase().includes(term)),
     );
   }, [wines, searchTerm]);
 
   // Reverse pairing AI
-  const { callGeminiProxy: findWineForFood, response: reversePairing, loading: isLoadingAI, error: pairingError } = useFoodPairingAI();
+  const {
+    callGeminiProxy: findWineForFood,
+    response: reversePairing,
+    loading: isLoadingAI,
+    error: pairingError,
+  } = useFoodPairingAI();
 
   // CRUD actions
   const {
@@ -120,23 +226,29 @@ export default function HomePage() {
     handleEraseAllWines,
     isLoadingAction,
     actionError,
-    setActionError
-  } = useWineActions(db, user?.uid, appId, msg => setCsvImportStatus({ message: msg, type: 'error', errors: [] }));
+    setActionError,
+  } = useWineActions(db, user?.uid, appId, (msg) =>
+    setCsvImportStatus({ message: msg, type: "error", errors: [] }),
+  );
 
   // Global error
   const globalError = dataError || authError || actionError || pairingError;
 
   const registerWithVerification = async (email, password) => {
-    setVerificationError('');
+    setVerificationError("");
+    setVerificationMessage("");
     const code = Math.floor(100000 + Math.random() * 900000).toString();
     try {
-      const res = await fetch('/api/sendVerificationEmail', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, code })
+      const res = await fetch("/api/sendVerificationEmail", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, code }),
       });
-      if (!res.ok) throw new Error('Failed to send verification email');
+      if (!res.ok) throw new Error("Failed to send verification email");
       setPendingRegistration({ email, password, code });
+      setVerificationMessage(
+        "Verification email sent. Please check your inbox.",
+      );
       setShowVerificationModal(true);
       return { success: true };
     } catch (err) {
@@ -148,15 +260,18 @@ export default function HomePage() {
   const verifyCodeAndRegister = async (enteredCode) => {
     if (!pendingRegistration) return;
     if (enteredCode !== pendingRegistration.code) {
-      setVerificationError('Incorrect verification code.');
+      setVerificationError("Incorrect verification code.");
       return;
     }
-    const res = await register(pendingRegistration.email, pendingRegistration.password);
+    const res = await register(
+      pendingRegistration.email,
+      pendingRegistration.password,
+    );
     if (res?.success) {
       setShowVerificationModal(false);
       setPendingRegistration(null);
     } else {
-      setVerificationError(res.error || 'Registration failed.');
+      setVerificationError(res.error || "Registration failed.");
     }
   };
 
@@ -164,19 +279,24 @@ export default function HomePage() {
   const handleImportCsv = async () => {
     if (!csvFile) return;
     const reader = new FileReader();
-    reader.onload = async e => {
+    reader.onload = async (e) => {
       try {
         const { data: parsed } = parseCsv(e.target.result);
         for (const w of parsed) await handleAddWine(w, wines);
-        setCsvImportStatus({ message: 'Imported successfully!', type: 'success', errors: [] });
+        setCsvImportStatus({
+          message: "Imported successfully!",
+          type: "success",
+          errors: [],
+        });
       } catch (err) {
-        setCsvImportStatus({ message: err.message, type: 'error', errors: [] });
+        setCsvImportStatus({ message: err.message, type: "error", errors: [] });
       }
     };
     reader.readAsText(csvFile);
   };
-  const handleExportCsv = () => exportToCsv(wines, 'my_cellar.csv');
-  const handleExportExperiencedCsv = () => exportToCsv(experiencedWines, 'experienced_wines.csv');
+  const handleExportCsv = () => exportToCsv(wines, "my_cellar.csv");
+  const handleExportExperiencedCsv = () =>
+    exportToCsv(experiencedWines, "experienced_wines.csv");
 
   const handleFindWineForFood = async () => {
     setShowReversePairingModal(true);
@@ -185,16 +305,16 @@ export default function HomePage() {
   const fetchFoodPairing = async (wine) => {
     if (!wine) return;
     setIsLoadingPairing(true);
-    setPairingSuggestion('');
+    setPairingSuggestion("");
     try {
-      const prompt = `Suggest 1-3 foods that would pair well with the wine: ${wine.producer} ${wine.name ? '(' + wine.name + ')' : ''} ${wine.region} ${wine.year || ''}.`;
-      const res = await fetch('/api/gemini', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const prompt = `Suggest 1-3 foods that would pair well with the wine: ${wine.producer} ${wine.name ? "(" + wine.name + ")" : ""} ${wine.region} ${wine.year || ""}.`;
+      const res = await fetch("/api/gemini", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           contents: [
             {
-              role: 'user',
+              role: "user",
               parts: [{ text: prompt }],
             },
           ],
@@ -202,7 +322,9 @@ export default function HomePage() {
       });
       if (!res.ok) throw new Error(await res.text());
       const data = await res.json();
-      const output = data?.candidates?.[0]?.content?.parts?.[0]?.text || 'No suggestion available.';
+      const output =
+        data?.candidates?.[0]?.content?.parts?.[0]?.text ||
+        "No suggestion available.";
       setPairingSuggestion(output);
     } catch (err) {
       setPairingSuggestion(`Error: ${err.message}`);
@@ -214,7 +336,9 @@ export default function HomePage() {
   // Loading auth state
   if (isLoadingAuth || !isAuthReady) {
     return (
-      <div className="flex items-center justify-center h-screen"><LoadingSpinner /></div>
+      <div className="flex items-center justify-center h-screen">
+        <LoadingSpinner />
+      </div>
     );
   }
 
@@ -234,11 +358,20 @@ export default function HomePage() {
             </div>
           )}
           {user ? (
-            <button onClick={logout} className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded">
+            <button
+              onClick={logout}
+              className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded"
+            >
               Logout
             </button>
           ) : (
-            <button onClick={() => { setShowAuthModal(true); setIsRegister(false); }} className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded">
+            <button
+              onClick={() => {
+                setShowAuthModal(true);
+                setIsRegister(false);
+              }}
+              className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded"
+            >
               Login
             </button>
           )}
@@ -246,35 +379,37 @@ export default function HomePage() {
       </header>
 
       {/* Error Banner */}
-      {globalError && <AlertMessage message={globalError} type="error" onDismiss={() => {}} />}
+      {globalError && (
+        <AlertMessage message={globalError} type="error" onDismiss={() => {}} />
+      )}
 
       {/* Navigation */}
       <nav className="flex space-x-2 p-4 bg-white dark:bg-slate-800 overflow-x-auto whitespace-nowrap">
         {[
-          ['cellar','Cellar', WineBottleIcon],
-          ['drinksoon','Drink Soon', ClockIcon],
-          ['experienced','Experienced', StarIcon],
-          ['pairing','Food Pairing', SparklesIcon],
-          ['importExport','Import/Export', UploadIcon],
-          ['help','Help', QuestionMarkCircleIcon]
-        ].map(([key,label,Icon]) => (
+          ["cellar", "Cellar", WineBottleIcon],
+          ["drinksoon", "Drink Soon", ClockIcon],
+          ["experienced", "Experienced", StarIcon],
+          ["pairing", "Food Pairing", SparklesIcon],
+          ["importExport", "Import/Export", UploadIcon],
+          ["help", "Help", QuestionMarkCircleIcon],
+        ].map(([key, label, Icon]) => (
           <button
             key={key}
             onClick={() => setView(key)}
-            className={`px-3 py-1 rounded flex items-center space-x-1 ${view===key?'bg-blue-600 text-white':'bg-gray-200 dark:bg-slate-700'}`}
+            className={`px-3 py-1 rounded flex items-center space-x-1 ${view === key ? "bg-blue-600 text-white" : "bg-gray-200 dark:bg-slate-700"}`}
           >
             <Icon className="w-4 h-4" />
             <span>{label}</span>
           </button>
         ))}
       </nav>
-      {(view==='cellar' || view==='drinksoon') && (
+      {(view === "cellar" || view === "drinksoon") && (
         <div className="p-4 bg-white dark:bg-slate-800">
           <input
             type="text"
             placeholder="Search wines..."
             value={searchTerm}
-            onChange={e => setSearchTerm(e.target.value)}
+            onChange={(e) => setSearchTerm(e.target.value)}
             className="w-full max-w-md p-2 border border-slate-300 dark:border-slate-600 rounded focus:outline-none"
           />
         </div>
@@ -282,49 +417,49 @@ export default function HomePage() {
 
       {/* Main Content */}
       <main className="p-6 space-y-10">
-        {view==='cellar' && (
+        {view === "cellar" && (
           <CellarView
             wines={filteredWines}
             isLoading={isLoadingData}
             isLoadingAction={isLoadingAction}
-            handleOpenWineForm={wine => setWineToEdit(wine)}
-            confirmExperienceWine={wine => setWineToExperience(wine)}
-            handleOpenFoodPairing={wine => setPairingWine(wine)}
+            handleOpenWineForm={(wine) => setWineToEdit(wine)}
+            confirmExperienceWine={(wine) => setWineToExperience(wine)}
+            handleOpenFoodPairing={(wine) => setPairingWine(wine)}
           />
         )}
-        {view==='drinksoon' && (
+        {view === "drinksoon" && (
           <DrinkSoonView
             // ◀ PASS the full list
             wines={filteredWines}
             // callbacks to open modal or trigger actions
-            handleOpenWineForm={wine => setWineToEdit(wine)}
-            confirmExperienceWine={wine => setWineToExperience(wine)}
-            handleOpenFoodPairing={wine => setPairingWine(wine)}
+            handleOpenWineForm={(wine) => setWineToEdit(wine)}
+            confirmExperienceWine={(wine) => setWineToExperience(wine)}
+            handleOpenFoodPairing={(wine) => setPairingWine(wine)}
             isLoadingAction={isLoadingAction}
             error={actionError}
             setError={setActionError}
-			/>
+          />
         )}
-        {view==='experienced' && (
+        {view === "experienced" && (
           <ExperiencedWinesView
             experiencedWines={experiencedWines}
             onDelete={handleDeleteExperiencedWine}
           />
         )}
-        {view==='pairing' && (
+        {view === "pairing" && (
           <FoodPairingView
             foodForReversePairing={foodForReversePairing}
             setFoodForReversePairing={setFoodForReversePairing}
             handleFindWineForFood={handleFindWineForFood}
             isLoadingReversePairing={isLoadingAI}
             wines={wines}
-            goToCellar={() => setView('cellar')}
+            goToCellar={() => setView("cellar")}
           />
         )}
-        {view==='importExport' && (
+        {view === "importExport" && (
           <ImportExportView
             csvFile={csvFile}
-            handleCsvFileChange={e=>setCsvFile(e.target.files[0])}
+            handleCsvFileChange={(e) => setCsvFile(e.target.files[0])}
             handleImportCsv={handleImportCsv}
             isImportingCsv={isLoadingAction}
             csvImportStatus={csvImportStatus}
@@ -333,19 +468,21 @@ export default function HomePage() {
             experiencedWines={experiencedWines}
             handleExportCsv={handleExportCsv}
             handleExportExperiencedCsv={handleExportExperiencedCsv}
-            confirmEraseAllWines={()=>window.confirm('Really erase all wines?')&&handleEraseAllWines()}
+            confirmEraseAllWines={() =>
+              window.confirm("Really erase all wines?") && handleEraseAllWines()
+            }
           />
         )}
-        {view==='help' && <HelpView />}
+        {view === "help" && <HelpView />}
       </main>
 
       {/* Modals */}
       {wineToEdit && (
         <WineFormModal
           isOpen
-          onClose={()=>setWineToEdit(null)}
+          onClose={() => setWineToEdit(null)}
           wine={wineToEdit}
-          onSubmit={async data => {
+          onSubmit={async (data) => {
             const res = wineToEdit.id
               ? await handleUpdateWine(wineToEdit.id, data, wines)
               : await handleAddWine(data, wines);
@@ -367,7 +504,10 @@ export default function HomePage() {
       {pairingWine && (
         <FoodPairingModal
           isOpen
-          onClose={() => { setPairingWine(null); setPairingSuggestion(''); }}
+          onClose={() => {
+            setPairingWine(null);
+            setPairingSuggestion("");
+          }}
           wine={pairingWine}
           suggestion={pairingSuggestion}
           isLoading={isLoadingPairing}
@@ -386,13 +526,13 @@ export default function HomePage() {
       {showAuthModal && (
         <AuthModal
           isOpen
-          onClose={()=>setShowAuthModal(false)}
+          onClose={() => setShowAuthModal(false)}
           isRegister={isRegister}
           setIsRegister={setIsRegister}
           onLogin={login}
           onRegister={registerWithVerification}
           onPasswordReset={resetPassword}
-          error={authError}
+          error={isRegister ? verificationError || authError : authError}
           loading={isLoadingAuth}
         />
       )}
@@ -402,6 +542,7 @@ export default function HomePage() {
           onClose={() => setShowVerificationModal(false)}
           onVerify={verifyCodeAndRegister}
           error={verificationError}
+          message={verificationMessage}
         />
       )}
     </div>

--- a/components/AuthModal.js
+++ b/components/AuthModal.js
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect } from 'react';
-import Modal from './Modal';
-import AlertMessage from './AlertMessage';
-import PasswordResetModal from './PasswordResetModal';
+import React, { useState, useEffect } from "react";
+import Modal from "./Modal";
+import AlertMessage from "./AlertMessage";
+import PasswordResetModal from "./PasswordResetModal";
 
 const AuthModal = ({
   isOpen,
@@ -14,42 +14,44 @@ const AuthModal = ({
   onRegister,
   onPasswordReset,
   error,
-  loading
+  loading,
 }) => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [localError, setLocalError] = useState('');
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [localError, setLocalError] = useState("");
   const [showResetModal, setShowResetModal] = useState(false);
 
   // Reset fields when the modal closes
   useEffect(() => {
     if (!isOpen) {
-      setEmail('');
-      setPassword('');
-      setLocalError('');
+      setEmail("");
+      setPassword("");
+      setLocalError("");
       setShowResetModal(false);
     }
   }, [isOpen]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setLocalError('');
+    setLocalError("");
 
     if (!email || !password) {
-      setLocalError('Email and password are required.');
+      setLocalError("Email and password are required.");
       return;
     }
     if (password.length < 6) {
-      setLocalError('Password should be at least 6 characters.');
+      setLocalError("Password should be at least 6 characters.");
       return;
     }
 
     try {
+      let res;
       if (isRegister) {
-        await onRegister(email, password);
+        res = await onRegister(email, password);
       } else {
-        await onLogin(email, password);
+        res = await onLogin(email, password);
       }
+      if (!res?.success) return;
       // on success: close modal and reset to login mode
       setIsRegister(false);
       onClose();
@@ -59,17 +61,24 @@ const AuthModal = ({
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title={isRegister ? 'Register' : 'Login'}>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={isRegister ? "Register" : "Login"}
+    >
       <form onSubmit={handleSubmit} className="space-y-4">
         {(localError || error) && (
           <AlertMessage
             message={localError || error}
             type="error"
-            onDismiss={() => setLocalError('')}
+            onDismiss={() => setLocalError("")}
           />
         )}
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+          <label
+            htmlFor="email"
+            className="block text-sm font-medium text-slate-700 dark:text-slate-300"
+          >
             Email
           </label>
           <input
@@ -82,7 +91,10 @@ const AuthModal = ({
           />
         </div>
         <div>
-          <label htmlFor="password" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+          <label
+            htmlFor="password"
+            className="block text-sm font-medium text-slate-700 dark:text-slate-300"
+          >
             Password
           </label>
           <input
@@ -108,12 +120,30 @@ const AuthModal = ({
             className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {loading ? (
-              <svg className="animate-spin h-5 w-5 text-white mx-auto" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+              <svg
+                className="animate-spin h-5 w-5 text-white mx-auto"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
               </svg>
+            ) : isRegister ? (
+              "Register"
             ) : (
-              isRegister ? 'Register' : 'Login'
+              "Login"
             )}
           </button>
         </div>
@@ -121,19 +151,28 @@ const AuthModal = ({
       <p className="mt-4 text-center text-sm">
         {isRegister ? (
           <>
-            Already have an account?{' '}
-            <button onClick={() => setIsRegister(false)} className="text-red-600 hover:underline">
+            Already have an account?{" "}
+            <button
+              onClick={() => setIsRegister(false)}
+              className="text-red-600 hover:underline"
+            >
               Login
             </button>
           </>
         ) : (
           <>
-            New here?{' '}
-            <button onClick={() => setIsRegister(true)} className="text-red-600 hover:underline">
+            New here?{" "}
+            <button
+              onClick={() => setIsRegister(true)}
+              className="text-red-600 hover:underline"
+            >
               Register
             </button>
             <br />
-            <button onClick={() => setShowResetModal(true)} className="text-red-600 hover:underline mt-2">
+            <button
+              onClick={() => setShowResetModal(true)}
+              className="text-red-600 hover:underline mt-2"
+            >
               Forgot password?
             </button>
           </>

--- a/components/EmailVerificationModal.js
+++ b/components/EmailVerificationModal.js
@@ -1,25 +1,31 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect } from 'react';
-import Modal from './Modal';
-import AlertMessage from './AlertMessage';
+import React, { useState, useEffect } from "react";
+import Modal from "./Modal";
+import AlertMessage from "./AlertMessage";
 
-const EmailVerificationModal = ({ isOpen, onClose, onVerify, error }) => {
-  const [code, setCode] = useState('');
-  const [localError, setLocalError] = useState('');
+const EmailVerificationModal = ({
+  isOpen,
+  onClose,
+  onVerify,
+  error,
+  message,
+}) => {
+  const [code, setCode] = useState("");
+  const [localError, setLocalError] = useState("");
 
   useEffect(() => {
     if (!isOpen) {
-      setCode('');
-      setLocalError('');
+      setCode("");
+      setLocalError("");
     }
   }, [isOpen]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    setLocalError('');
+    setLocalError("");
     if (!code) {
-      setLocalError('Verification code is required.');
+      setLocalError("Verification code is required.");
       return;
     }
     onVerify(code);
@@ -28,15 +34,19 @@ const EmailVerificationModal = ({ isOpen, onClose, onVerify, error }) => {
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Verify Email">
       <form onSubmit={handleSubmit} className="space-y-4">
+        {message && <AlertMessage message={message} type="info" />}
         {(localError || error) && (
           <AlertMessage
             message={localError || error}
             type="error"
-            onDismiss={() => setLocalError('')}
+            onDismiss={() => setLocalError("")}
           />
         )}
         <div>
-          <label htmlFor="verificationCode" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+          <label
+            htmlFor="verificationCode"
+            className="block text-sm font-medium text-slate-700 dark:text-slate-300"
+          >
             Verification Code
           </label>
           <input
@@ -69,4 +79,3 @@ const EmailVerificationModal = ({ isOpen, onClose, onVerify, error }) => {
 };
 
 export default EmailVerificationModal;
-


### PR DESCRIPTION
## Summary
- preserve Auth modal when registration fails
- show success message after verification email is sent
- forward verification errors to registration modal
- display info message in verification modal

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*
- `npm run build` *(fails: Failed to fetch font files from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_6870cda71f548330a327db233691b59c