### PR TITLE
Improve email verification error display

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -244,7 +244,17 @@ export default function HomePage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, code }),
       });
-      if (!res.ok) throw new Error("Failed to send verification email");
+
+      if (!res.ok) {
+        let msg = "Failed to send verification email";
+        try {
+          const data = await res.json();
+          if (data && data.error) msg = data.error;
+        } catch (e) {
+          // ignore JSON parse errors
+        }
+        throw new Error(msg);
+      }
       setPendingRegistration({ email, password, code });
       setVerificationMessage(
         "Verification email sent. Please check your inbox.",


### PR DESCRIPTION
## Summary
- surface API error when sending verification email fails

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_6870da022d6483308a87e2cdfcef47d7