### PR TITLE
Add debug logs around password reset

### DIFF
--- a/hooks/useAuthManager.js
+++ b/hooks/useAuthManager.js
@@ -53,9 +53,12 @@ export const useAuthManager = (authInstance) => {
     setIsLoadingAuth(true);
     setAuthError(null);
     try {
+      console.debug('Attempting to send password reset email to', email);
       await sendPasswordResetEmail(authInstance, email);
+      console.debug('Password reset email request sent successfully');
       return { success: true };
     } catch (error) {
+      console.error('sendPasswordResetEmail failed:', error);
       let message = 'Failed to send password reset email.';
       if (error.code === 'auth/user-not-found') {
         message = 'No account found with this email.';


### PR DESCRIPTION
## Summary
- emit console debug and error logs around `sendPasswordResetEmail` in `useAuthManager`

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68711f6af57483309a81d74670ddeb9a