### PR TITLE
Improve password reset debug and UI

### DIFF
--- a/components/AuthModal.js
+++ b/components/AuthModal.js
@@ -183,6 +183,7 @@ const AuthModal = ({
           isOpen={showResetModal}
           onClose={() => setShowResetModal(false)}
           onReset={onPasswordReset}
+          loading={loading}
         />
       )}
     </Modal>

--- a/components/PasswordResetModal.js
+++ b/components/PasswordResetModal.js
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
 import Modal from './Modal';
 import AlertMessage from './AlertMessage';
 
-const PasswordResetModal = ({ isOpen, onClose, onReset }) => {
+const PasswordResetModal = ({ isOpen, onClose, onReset, loading = false }) => {
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
   const [type, setType] = useState('info');
@@ -19,11 +19,14 @@ const PasswordResetModal = ({ isOpen, onClose, onReset }) => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    console.log('Password reset form submitted for', email);
     if (!email) {
       setMessage('Email is required.');
       setType('error');
       return;
     }
+    setMessage('Sending password reset email...');
+    setType('info');
     const res = await onReset(email);
     if (res?.success) {
       setMessage(`If an account exists for ${email}, a reset link has been sent.`);
@@ -67,9 +70,22 @@ const PasswordResetModal = ({ isOpen, onClose, onReset }) => {
           </button>
           <button
             type="submit"
-            className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md shadow-sm"
+            disabled={loading}
+            className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            Send
+            {loading ? (
+              <svg
+                className="animate-spin h-5 w-5 text-white mx-auto"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+              </svg>
+            ) : (
+              'Send'
+            )}
           </button>
         </div>
       </form>

--- a/hooks/useAuthManager.js
+++ b/hooks/useAuthManager.js
@@ -53,9 +53,12 @@ export const useAuthManager = (authInstance) => {
     setIsLoadingAuth(true);
     setAuthError(null);
     try {
+      console.log('Attempting to send password reset email to', email);
       await sendPasswordResetEmail(authInstance, email);
+      console.log('Password reset email request sent successfully');
       return { success: true };
     } catch (error) {
+      console.error('sendPasswordResetEmail failed:', error);
       let message = 'Failed to send password reset email.';
       if (error.code === 'auth/user-not-found') {
         message = 'No account found with this email.';


### PR DESCRIPTION
## Summary
- convert password reset debug logs to `console.log`
- surface status messages in `PasswordResetModal`
- show a spinner while sending the email
- pass auth loading state to the reset modal

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68711f6af57483309a81d74670ddeb9a