### PR TITLE
Show wine counts and expand CSV export

### DIFF
--- a/utils/csvUtils.js
+++ b/utils/csvUtils.js
@@ -71,6 +71,8 @@ export const exportToCsv = (data, fileName, headers, isExperienced = false) => {
     ];
 
     data.forEach(item => {
+        const startYear = item.drinkingWindowStartYear ?? '';
+        const endYear = item.drinkingWindowEndYear ?? '';
         const row = isExperienced ? [
             escapeCsvField(item.name),
             escapeCsvField(item.producer),
@@ -78,8 +80,8 @@ export const exportToCsv = (data, fileName, headers, isExperienced = false) => {
             escapeCsvField(item.region),
             escapeCsvField(item.color),
             escapeCsvField(item.location),
-            escapeCsvField(item.drinkingWindowStartYear),
-            escapeCsvField(item.drinkingWindowEndYear),
+            escapeCsvField(startYear),
+            escapeCsvField(endYear),
             escapeCsvField(item.consumedAt ? (item.consumedAt instanceof Timestamp ? item.consumedAt.toDate().toISOString().slice(0, 10) : new Date(item.consumedAt).toISOString().slice(0, 10)) : ''),
             escapeCsvField(item.rating),
             escapeCsvField(item.tastingNotes)
@@ -90,8 +92,8 @@ export const exportToCsv = (data, fileName, headers, isExperienced = false) => {
             escapeCsvField(item.region),
             escapeCsvField(item.color),
             escapeCsvField(item.location),
-            escapeCsvField(item.drinkingWindowStartYear),
-            escapeCsvField(item.drinkingWindowEndYear)
+            escapeCsvField(startYear),
+            escapeCsvField(endYear)
         ];
         csvRows.push(row.join(';'));
     });

--- a/views/DrinkSoonView/DrinkSoonView.js
+++ b/views/DrinkSoonView/DrinkSoonView.js
@@ -46,6 +46,9 @@ const DrinkSoonView = ({
           <p className="text-sm text-yellow-700 dark:text-yellow-400 mb-4">
             These wines are past or approaching their ideal drinking window.
           </p>
+          <p className="text-sm text-yellow-700 dark:text-yellow-400 mb-4">
+            Number of Wines: {winesApproachingEnd.length}
+          </p>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {winesApproachingEnd.map(wine => (
               <WineItem

--- a/views/cellar/CellarView.js
+++ b/views/cellar/CellarView.js
@@ -25,6 +25,13 @@ const CellarView = ({
         <AddWineButton onAdd={() => handleOpenWineForm({})} />
       </div>
 
+      {/* Show number of wines */}
+      {!isLoading && (
+        <p className="text-sm text-slate-600 dark:text-slate-300 mb-4">
+          Total Wines: {allWines.length}
+        </p>
+      )}
+
       {(isLoading || isLoadingAction) && (
         <div className="flex justify-center mb-6">
           <LoadingSpinner />

--- a/views/experienced/ExperiencedWinesView.js
+++ b/views/experienced/ExperiencedWinesView.js
@@ -38,6 +38,9 @@ const ExperiencedWinesView = ({ experiencedWines: experiencedWinesProp, onDelete
   return (
     <>
       <h2 className="text-2xl font-semibold text-slate-700 dark:text-slate-200 mb-4 mt-8">Experienced Wines</h2>
+      <p className="text-sm text-slate-600 dark:text-slate-300 mb-4">
+        Total Wines: {winesList.length}
+      </p>
 
       {winesList.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary
- display total wines in cellar, drink soon, and experienced views
- include drinking window start and end when exporting CSVs

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68717be7925483309ed8088bffc29971