### PR TITLE
Add debug logging for password reset endpoint

### DIFF
--- a/app/api/sendPasswordResetEmail/route.js
+++ b/app/api/sendPasswordResetEmail/route.js
@@ -10,13 +10,30 @@ function initAdmin() {
   const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
   const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n');
 
+  console.debug('Loading Firebase Admin credentials', {
+    projectIdExists: Boolean(projectId),
+    clientEmailExists: Boolean(clientEmail),
+    privateKeyLength: privateKey?.length,
+  });
+
   if (!projectId || !clientEmail || !privateKey) {
+    console.error('Firebase Admin credentials not configured', {
+      projectIdExists: Boolean(projectId),
+      clientEmailExists: Boolean(clientEmail),
+      privateKeyExists: Boolean(privateKey),
+    });
     throw new Error('Firebase Admin credentials not configured.');
   }
 
-  initializeApp({
-    credential: cert({ projectId, clientEmail, privateKey })
-  });
+  try {
+    initializeApp({
+      credential: cert({ projectId, clientEmail, privateKey })
+    });
+    console.debug('Firebase Admin initialized');
+  } catch (err) {
+    console.error('Failed to initialize Firebase Admin', err);
+    throw err;
+  }
 }
 
 export async function POST(request) {
@@ -28,6 +45,10 @@ export async function POST(request) {
   }
 
   const apiKey = process.env.RESEND_API_KEY;
+  console.debug('Loaded Resend environment', {
+    apiKeyExists: Boolean(apiKey),
+  });
+
   if (!apiKey) {
     return NextResponse.json({ error: 'Resend API key not configured.' }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- add detailed logging during Firebase Admin initialization
- log presence of Resend API key

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872179c75f08330927308f7e424bcdb