### PR TITLE
Improve debug visibility for password reset API

### DIFF
--- a/app/api/sendPasswordResetEmail/route.js
+++ b/app/api/sendPasswordResetEmail/route.js
@@ -3,37 +3,85 @@ import { Resend } from 'resend';
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
 
-function initAdmin() {
+export const runtime = 'nodejs';
+
+function createLogger(store) {
+  return (...args) => {
+    const msg = args
+      .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+      .join(' ');
+    store.push(msg);
+    console.log(...args);
+  };
+}
+
+function initAdmin(log = console.log) {
   if (getApps().length) return;
 
   const projectId = process.env.FIREBASE_PROJECT_ID;
   const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
-  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n');
+  let rawKey = process.env.FIREBASE_PRIVATE_KEY;
+  if (rawKey && rawKey.includes('\\n')) {
+    rawKey = rawKey.replace(/\\n/g, '\n');
+  }
+  if (rawKey && !rawKey.includes('BEGIN')) {
+    try {
+      rawKey = Buffer.from(rawKey, 'base64').toString('utf8');
+    } catch (err) {
+      console.error('Failed to decode FIREBASE_PRIVATE_KEY', err);
+    }
+  }
+  const privateKey = rawKey;
+
+  log('Loading Firebase Admin credentials', {
+    projectIdExists: Boolean(projectId),
+    clientEmailExists: Boolean(clientEmail),
+    privateKeyLength: privateKey?.length,
+  });
 
   if (!projectId || !clientEmail || !privateKey) {
+    log('Firebase Admin credentials not configured', {
+      projectIdExists: Boolean(projectId),
+      clientEmailExists: Boolean(clientEmail),
+      privateKeyExists: Boolean(privateKey),
+    });
     throw new Error('Firebase Admin credentials not configured.');
   }
 
-  initializeApp({
-    credential: cert({ projectId, clientEmail, privateKey })
-  });
+  try {
+    initializeApp({
+      credential: cert({ projectId, clientEmail, privateKey })
+    });
+    log('Firebase Admin initialized');
+  } catch (err) {
+    console.error('Failed to initialize Firebase Admin', err);
+    throw err;
+  }
 }
 
 export async function POST(request) {
+  const logs = [];
+  const log = createLogger(logs);
+  const includeLogs = request.nextUrl.searchParams.get('debug') === 'true';
+
   const { email } = await request.json();
-  console.debug('Password reset email request received', { email });
+  log('Password reset email request received', { email });
 
   if (!email) {
     return NextResponse.json({ error: 'Missing email.' }, { status: 400 });
   }
 
   const apiKey = process.env.RESEND_API_KEY;
+  log('Loaded Resend environment', {
+    apiKeyExists: Boolean(apiKey),
+  });
+
   if (!apiKey) {
     return NextResponse.json({ error: 'Resend API key not configured.' }, { status: 500 });
   }
 
   try {
-    initAdmin();
+    initAdmin(log);
     const auth = getAuth();
     const link = await auth.generatePasswordResetLink(email);
 
@@ -44,12 +92,12 @@ export async function POST(request) {
       subject: 'Password reset',
       text: `Click the link below to reset your password:\n\n${link}`,
     });
-    console.debug('Password reset email sent successfully');
-    return NextResponse.json({ success: true });
+    log('Password reset email sent successfully');
+    return NextResponse.json({ success: true, logs: includeLogs ? logs : undefined });
   } catch (err) {
     console.error('Error sending password reset email', err);
     return NextResponse.json(
-      { error: `Failed to send email: ${err.message}` },
+      { error: `Failed to send email: ${err.message}`, logs: includeLogs ? logs : undefined },
       { status: 500 }
     );
   }

--- a/app/api/sendVerificationEmail/route.js
+++ b/app/api/sendVerificationEmail/route.js
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server';
 import { Resend } from 'resend';
 
+export const runtime = 'nodejs';
+
 export async function POST(request) {
   const { email, code } = await request.json();
-  console.debug('Verification email request received', { email, code });
+  console.log('Verification email request received', { email, code });
 
   if (!email || !code) {
     return NextResponse.json({ error: 'Missing parameters.' }, { status: 400 });
@@ -11,7 +13,7 @@ export async function POST(request) {
 
   const apiKey = process.env.RESEND_API_KEY;
 
-  console.debug('Loaded Resend environment', {
+  console.log('Loaded Resend environment', {
     apiKeyExists: Boolean(apiKey),
   });
 
@@ -24,17 +26,17 @@ export async function POST(request) {
 
   const resend = new Resend(apiKey);
 
-  console.debug('Resend client configured');
+  console.log('Resend client configured');
 
   try {
-    console.debug('Sending verification email to', email);
+    console.log('Sending verification email to', email);
     await resend.emails.send({
       from: 'MyCellar <noreply@mycellarapp.com>',
       to: email,
       subject: 'Your verification code',
       text: `Your verification code is ${code}`,
     });
-    console.debug('Verification email sent successfully');
+    console.log('Verification email sent successfully');
     return NextResponse.json({ success: true });
   } catch (err) {
     console.error('Error sending verification email', err);


### PR DESCRIPTION
## Summary
- capture logs server-side and optionally return them in password reset API

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_6872179c75f08330927308f7e424bcdb