### PR TITLE
Improve verification messaging

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -257,12 +257,14 @@ export default function HomePage() {
       }
       setPendingRegistration({ email, password, code });
       setVerificationMessage(
-        "Verification email sent. Please check your inbox.",
+        "Verification email sent. Please check your inbox and spam folder. If you don't see it soon, close this window and try registering again.",
       );
       setShowVerificationModal(true);
       return { success: true };
     } catch (err) {
-      setVerificationError(err.message);
+      setVerificationError(
+        `${err.message}. If you didn't get the email, double-check the address and try again.`,
+      );
       return { success: false };
     }
   };
@@ -281,7 +283,9 @@ export default function HomePage() {
       setShowVerificationModal(false);
       setPendingRegistration(null);
     } else {
-      setVerificationError(res.error || "Registration failed.");
+      setVerificationError(
+        `${res.error || "Registration failed."} If the problem persists, try requesting a new verification code.`,
+      );
     }
   };
 

--- a/components/EmailVerificationModal.js
+++ b/components/EmailVerificationModal.js
@@ -35,6 +35,12 @@ const EmailVerificationModal = ({
     <Modal isOpen={isOpen} onClose={onClose} title="Verify Email">
       <form onSubmit={handleSubmit} className="space-y-4">
         {message && <AlertMessage message={message} type="info" />}
+        {!message && (
+          <AlertMessage
+            message="Enter the 6-digit code we just emailed. If you don't see it, check your spam folder or close this window and try registering again."
+            type="info"
+          />
+        )}
         {(localError || error) && (
           <AlertMessage
             message={localError || error}


### PR DESCRIPTION
## Summary
- show helpful instructions in email verification modal
- surface next-step hints on verification errors

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals")*
- `npm run build` *(fails: failed to fetch fonts from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_6876736d29ac833086851ee4616af65b