### PR TITLE
[codex] update Gemini Flash Lite GA model

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ If any of the required variables are missing, the app will log an error and disa
 
 ```bash
 GEMINI_API_KEY=...
-# Default now targets Gemini 3.1 Flash Lite (Preview)
-GEMINI_MODEL=gemini-3.1-flash-lite-preview  # optional; 2.0 IDs still auto-map to 2.5
+GEMINI_MODEL=gemini-3.1-flash-lite       # optional; recommended for Vercel/runtime parity with the current GA Flash Lite model
 GEMINI_API_VERSION=v1beta                # or v1 when available
 ```

--- a/app/api/gemini/route.js
+++ b/app/api/gemini/route.js
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
 
 // Defaults and helpers
-// Move default to Gemini 3.1 Flash Lite (Preview)
-const DEFAULT_MODEL = 'gemini-3.1-flash-lite-preview';
+const DEFAULT_MODEL = 'gemini-3.1-flash-lite';
 const DEFAULT_API_VERSION = (process.env.GEMINI_API_VERSION || 'v1beta').trim();
 
 function normalizeAndMapModel(envModel) {
@@ -86,7 +85,7 @@ export async function POST(request) {
       } else if (origLower.startsWith('gemini-2.0-flash')) {
         fallbackModel = 'gemini-2.5-flash';
       } else if (!mappingApplied) {
-        // Generic safety net: retry with our default 2.5 flash
+        // Generic safety net: retry with our default model
         fallbackModel = DEFAULT_MODEL;
       }
 


### PR DESCRIPTION
## What changed
- updated the server-side Gemini default model to `gemini-3.1-flash-lite`
- updated the setup documentation to recommend the GA Flash Lite model for runtime parity

## Why
Google is discontinuing the preview Gemini 3.1 Flash Lite model on May 25, 2026. This keeps the app pointed at the GA model identifier by default and documents the runtime configuration that should match it.

## Impact
- deployments that do not set `GEMINI_MODEL` will now default to the GA Flash Lite model
- deployments that do set `GEMINI_MODEL` should update that environment variable to `gemini-3.1-flash-lite`

## Validation
- ran `npm run lint`
- lint passed with one pre-existing warning in `components/WineFormModal.js` about a missing `useEffect` dependency